### PR TITLE
Replace insecure Math.random() with crypto.getRandomValues()

### DIFF
--- a/PassGen.js
+++ b/PassGen.js
@@ -25399,7 +25399,7 @@ let chngSep = document
 
 const secureRandom = (count) => {
   let num = 0;
-  const min = 2 << 32 % count;
+  const min = 2 ** 32 % count;
   const rand = new Uint32Array(1);
 
   do {

--- a/PassGen.js
+++ b/PassGen.js
@@ -25397,32 +25397,44 @@ let chngSep = document
     generatePassphrase();
   });
 
+const secureRandom = (count) => {
+  let num = 0;
+  const min = 2 << 32 % count;
+  const rand = new Uint32Array(1);
+
+  do {
+    num = crypto.getRandomValues(rand)[0];
+  } while (num < min);
+
+  return num % count;
+}
+
 function generatePassphrase() {
 
   let password = "";
-  addNumIndex = Math.floor(Math.random() * length);
-  addCharIndex = Math.floor(Math.random() * length);
+  addNumIndex = secureRandom(length);
+  addCharIndex = secureRandom(length);
 
   for (let i = 0; i < length; i++) {
     if (inclChar) {
       chars = "!@#$%^&*+<>?~";
-      selectedChar = chars.charAt(Math.floor(Math.random() * chars.length));
+      selectedChar = chars.charAt(secureRandom(chars.length));
       if (i == addCharIndex) {
         password += selectedChar;
       }
     }
 
-    let randomWord = wordsArray[Math.floor(Math.random() * wordsArray.length)];
+    let randomWord = wordsArray[secureRandom(wordsArray.length)];
     password += randomWord;
 
     if (inclNum) {
       if (i == addNumIndex) {
-        password += Math.floor(Math.random() * 10);
+        password += secureRandom(10);
       }
     }
 
     if (inclUpper) {
-      addUpperIndex = Math.floor(Math.random() * password.length);
+      addUpperIndex = secureRandom(password.length);
       password =
         password.slice(0, addUpperIndex) +
         password.charAt(addUpperIndex).toUpperCase() +

--- a/main.js
+++ b/main.js
@@ -74,7 +74,7 @@ const generatePassword = () => {
   }
   for (let i = 0; i < lengthSliderVal; i++) {
     generatedPassword += passwordSet.charAt(
-      Math.floor(Math.random() * passwordSet.length)
+      secureRandom(passwordSet.length)
     );
   }
   putPassword.innerText = generatedPassword;


### PR DESCRIPTION
`Math.random()` is not cryptographically secure, and as such is not suitable for generating passwords. As such, it is replaced with `crypto.getRandomValues()`.

`Math.floor(Math.random * length)` is also not uniform if `length` is not a multiple of a power of 2. As such, a `secureRandom(count)` function was built which uses modulo with rejection sampling to ensure every character or word when building the password or passphrase is uniform. Every instance of the multiply-and-floor method was replaced with this function.

These changes bring the password and passphrase generators up to standard with modern cryptographic best practices.